### PR TITLE
Qualified imports from Data.Csv

### DIFF
--- a/data_generators/FlowGen.hs
+++ b/data_generators/FlowGen.hs
@@ -3,7 +3,7 @@ module Main where
 
 import           Control.Monad
 import qualified Data.ByteString.Lazy  as B
-import           Data.Csv
+import qualified Data.Csv              as C
 import qualified Data.Foldable         as F
 import           Data.IORef
 import           Data.Sequence         (Seq, (<|), (><))
@@ -90,9 +90,10 @@ data Packet  = P
     , p_ts  :: {-# UNPACK #-} !Timestamp
     }
 
-instance ToRecord Packet where
+instance C.ToRecord Packet where
     toRecord (P pid src dst len ts) =
-        record [toField pid, toField src, toField dst, toField len, toField ts ]
+        C.record [ C.toField pid, C.toField src, C.toField dst
+                 , C.toField len, C.toField ts ]
 
 genHosts :: Int -> V.Vector Host
 genHosts n = V.enumFromN 1 n
@@ -120,7 +121,7 @@ genHostPairs opts hosts = do
     lookupHosts (src, dst) = (hosts ! src, hosts ! dst)
 
 writePackets :: Handle -> Seq Packet -> IO ()
-writePackets f ps = B.hPut f $ encode $ F.toList ps
+writePackets f ps = B.hPut f $ C.encode $ F.toList ps
 
 -- | Generate and write out all flows for a given pair of src and
 -- destination hosts

--- a/data_generators/OrganisationGen.hs
+++ b/data_generators/OrganisationGen.hs
@@ -8,7 +8,7 @@ module Main where
 import           Text.Printf
 import           Control.Monad.Reader
 import qualified Data.ByteString.Lazy  as B
-import           Data.Csv
+import qualified Data.Csv              as C
 import qualified Data.Foldable         as F
 import           Data.Vector           ((!))
 import qualified Data.Vector           as V
@@ -20,7 +20,7 @@ import qualified Data.Text as T
 
 newtype Client = Client Bool
 
-instance ToField Client where
+instance C.ToField Client where
     toField (Client True)  = "true"
     toField (Client False) = "false"
 
@@ -82,7 +82,7 @@ writeDepts :: DptGen (V.Vector T.Text)
 writeDepts = do
     dpts <- mkDepts
     f <- printf "departments%d.csv" <$> asks o_dpts
-    lift $ withFile f WriteMode $ \h -> B.hPut h (encode $ V.toList dpts)
+    lift $ withFile f WriteMode $ \h -> B.hPut h (C.encode $ V.toList dpts)
     return $ fmap snd dpts
 
 mkDepts :: DptGen (V.Vector (Key, T.Text))
@@ -112,7 +112,7 @@ writeEmps :: V.Vector T.Text -> DptGen (V.Vector T.Text)
 writeEmps dpts = do
     emps <- mkEmps dpts
     f <- printf "employees%d.csv" <$> asks o_dpts
-    lift $ withFile f WriteMode $ \h -> B.hPut h (encode $ V.toList emps)
+    lift $ withFile f WriteMode $ \h -> B.hPut h (C.encode $ V.toList emps)
     return $ fmap (\(_, _, n, _) -> n) emps
 
 writeTasks :: V.Vector T.Text -> DptGen ()
@@ -120,7 +120,7 @@ writeTasks emps = do
     tasks <- mapM mkTasks $ V.toList emps
     keyedTasks <-sequence $ zipWith ($) (concat tasks) [1..]
     f <- printf "tasks%d.csv" <$> asks o_dpts
-    lift $ withFile f WriteMode $ \h -> B.hPut h (encode keyedTasks)
+    lift $ withFile f WriteMode $ \h -> B.hPut h (C.encode keyedTasks)
 
 -- | Generate between one to four tasks for one employee
 mkTasks :: T.Text -> DptGen [Key -> DptGen (Key, T.Text, T.Text)]
@@ -149,7 +149,7 @@ writeContacts dpts = do
 mkContacts :: Int -> V.Vector T.Text -> Handle -> DptGen ()
 mkContacts k dpts h = do
     cs <- forM [(k::Int)+1..k+1000] (mkContact dpts)
-    lift $ B.hPut h (encode cs)
+    lift $ B.hPut h (C.encode cs)
 
 mkContact :: V.Vector T.Text -> Key -> DptGen (Key, T.Text, T.Text, Client)
 mkContact dpts k = do

--- a/data_generators/TradeGen.hs
+++ b/data_generators/TradeGen.hs
@@ -3,7 +3,7 @@ module Main where
 
 import           Control.Monad
 import qualified Data.ByteString.Lazy  as B
-import           Data.Csv
+import qualified Data.Csv              as C
 import qualified Data.Foldable         as F
 import           Data.Sequence         (Seq, (<|))
 import qualified Data.Sequence         as Seq
@@ -29,8 +29,8 @@ instance Enum Day where
     toEnum n = Day $ toEnum n
     fromEnum (Day d) = fromEnum d
 
-instance ToField Day where
-    toField (Day d) = toField $ C.showGregorian d
+instance C.ToField Day where
+    toField (Day d) = C.toField $ C.showGregorian d
 
 instance Show Day where
     show (Day d) = show d
@@ -42,9 +42,9 @@ data Trade = Trade
     , t_date  ::  !Day
     }
 
-instance ToRecord Trade where
+instance C.ToRecord Trade where
     toRecord (Trade p sid ts date) =
-        record [ toField p, toField sid, toField ts, toField date ]
+        C.record [ C.toField p, C.toField sid, C.toField ts, C.toField date ]
 
 {-
 
@@ -117,7 +117,7 @@ for each day d:
 -}
 
 writeTrades :: Options -> Seq Trade -> IO ()
-writeTrades opts trades = B.hPut (o_file opts) $ encode $ F.toList trades
+writeTrades opts trades = B.hPut (o_file opts) $ C.encode $ F.toList trades
 
 genTrades :: Options -> IO ()
 genTrades opts = do


### PR DESCRIPTION
Required for compatibility with cassava 0.5.1, which defines its own
Options data type that conflicts with Options defined in data generators